### PR TITLE
Fix multiline firerole handling in managedocfiles

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile_managedocfiles.py
+++ b/modules/bibdocfile/lib/bibdocfile_managedocfiles.py
@@ -1341,6 +1341,8 @@ def log_action(log_dir, action, bibdoc_name, file_path, rename,
         file_desc = open(log_file, "a+")
         # We must escape new lines from comments in some way:
         comment = str(comment).replace('\\', '\\\\').replace('\r\n', '\\n\\r')
+        # We must escape new lines from firerole restrictions too:
+        file_restriction = str(file_restriction).replace('\\', '\\\\').replace('\n', '\\n')
         msg = action                                 + '<--->' + \
               bibdoc_name.replace('---', '___')      + '<--->' + \
               file_path                              + '<--->' + \
@@ -1383,7 +1385,9 @@ def read_actions_log(log_dir):
 
             # Clean newline-escaped comment:
             comment = comment.replace('\\n\\r', '\r\n').replace('\\\\', '\\')
-
+            # Clean newline-escaped fireroles:
+            file_restriction = file_restriction.replace('\\n', '\n').replace('\\\\', '\\')
+            
             # Perform some checking
             if action not in CFG_ALLOWED_ACTIONS:
                 # Malformed action log


### PR DESCRIPTION
According to the docs, fireroles may include multiple rules, one per line separated by '\n'.
For example: "firerole: deny until '2011-01-01'
    allow any"
(note the ^M or \n before 'allow any')

When revising bibdocs with such restrictions in Document File Manager, (even when one does not change the 'Restrictions' dropdown) the firerole is 'cropped' in the first \n character, changing the actual rule!

With this patch, newlines are 'escaped' before written to the bibdocactions.log, so that the firerole is properly parsed and reapplied when the log is read.